### PR TITLE
Initilize QUERY_STRING as an empty string instead of None

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 Sippy Cup Changelog
 ===================
 
+Version 0.5.2
+-------------
+- fixed a bug where QUERY_STRING was initialized as None instead of an empty
+  string. This would break things like Flask's request.args.get('something')
+  if no query params were in the request
+
 Version 0.5.1
 -------------
 - added support / workaround for setting multiple cookies

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ config = {
     'url': 'https://bitbucket.org/realsalmon/sippycup',
     'author': 'Ben Jones',
     'author_email': 'ben@fogbutter.com',
-    'version': '0.5.1',
+    'version': '0.5.2',
     'packages': ['sippycup'],
     'name': 'sippycup',
     'install_requires': [],

--- a/sippycup/__init__.py
+++ b/sippycup/__init__.py
@@ -91,7 +91,7 @@ class WsgiEnviron(object):
     @property
     def query_string(self):
         if self.request['queryStringParameters'] is None:
-            return None
+            return ''
         else:
             return urlencode(self.request['queryStringParameters'])
 

--- a/tests/test_sippycup.py
+++ b/tests/test_sippycup.py
@@ -1,4 +1,4 @@
-from flask import Flask, Response, make_response, redirect
+from flask import Flask, Response, make_response, redirect, request
 from sippycup import sippycup
 from tests.utils import get_apigr
 
@@ -17,6 +17,11 @@ def cookies():
     r.set_cookie('b', '2')
     r.set_cookie('c', '3')
     return r
+
+
+@app.route('/test/query')
+def query():
+    return Response(request.args.get('a'), mimetype='text/plain')
 
 
 def test_response_body():
@@ -50,3 +55,19 @@ def test_response_cookies():
     event['path'] = '/test/cookies'
     result = sippycup(app, event)
     assert len([x for x in result['headers'] if x.lower() == 'set-cookie']) == 3
+
+
+def test_response_empty_query():
+    event = get_apigr()
+    event['path'] = '/test/query'
+    event['queryStringParameters'] = None
+    result = sippycup(app, event)
+    assert result['body'] == ''
+
+
+def test_response_query():
+    event = get_apigr()
+    event['path'] = '/test/query'
+    event['queryStringParameters'] = {'a': 'ohai'}
+    result = sippycup(app, event)
+    assert result['body'] == 'ohai'

--- a/tests/test_wsgi_environ.py
+++ b/tests/test_wsgi_environ.py
@@ -14,7 +14,7 @@ def test_wsgi_environ_basic():
         'REQUEST_METHOD': 'GET',
         'SCRIPT_NAME': '/testing',
         'PATH_INFO': '/',
-        'QUERY_STRING':  None,
+        'QUERY_STRING':  '',
         'CONTENT_TYPE': 'text/plain',
         'CONTENT_LENGTH': '0',
         'SERVER_NAME':  'testing.fogbutter.com',


### PR DESCRIPTION
  - this fixes a bug that causes failures in apps expecting the query string to be '' even when no query args are in the request